### PR TITLE
Add EPCO juyo data scraper

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -1,16 +1,82 @@
-# This is a sample Python script.
+import datetime as dt
+import re
+from io import BytesIO
+from pathlib import Path
+from urllib.parse import urljoin
+import shutil
+import requests
+from zipfile import ZipFile
 
-# Press Shift+F10 to execute it or replace it with your code.
-# Press Double Shift to search everywhere for classes, files, tool windows, actions, and settings.
+
+class epco:
+    """Scraper for EPCO electricity usage data."""
+
+    BASE_URL = "https://denkiyoho.hepco.co.jp/"
+
+    def juyo(self, date, area="hokkaido"):
+        """Download and extract electricity usage data.
+
+        Parameters
+        ----------
+        date : str | datetime.date | datetime.datetime
+            Date used to determine which dataset to download. An ISO formatted
+            string (``YYYY-MM-DD``) is also accepted.
+        area : str, optional
+            Electricity area. Currently only ``"hokkaido"`` is supported.
+
+        Returns
+        -------
+        list[str]
+            Paths to the extracted CSV files.
+        """
+        if isinstance(date, str):
+            date = dt.date.fromisoformat(date)
+        elif isinstance(date, dt.datetime):
+            date = date.date()
+        elif not isinstance(date, dt.date):
+            raise TypeError("date must be a date, datetime, or ISO format string")
+
+        start_months = {1: 1, 2: 1, 3: 1, 4: 4, 5: 4, 6: 4, 7: 7, 8: 7, 9: 7, 10: 10, 11: 10, 12: 10}
+        end_months = {1: 3, 2: 3, 3: 3, 4: 6, 5: 6, 6: 6, 7: 9, 8: 9, 9: 9, 10: 12, 11: 12, 12: 12}
+
+        start_month = start_months[date.month]
+        end_month = end_months[date.month]
+        year = date.year
+
+        filename = f"{year}{start_month:02d}-{end_month:02d}_{area}_denkiyohou.zip"
+
+        page_url = urljoin(self.BASE_URL, "area_download.html")
+        res = requests.get(page_url)
+        res.raise_for_status()
+        html = res.text
+
+        pattern = re.escape(f"area/data/zip/{filename}")
+        match = re.search(pattern, html)
+        if not match:
+            raise ValueError(f"No data link found for {date}")
+        href = match.group(0)
+        zip_url = urljoin(self.BASE_URL, href)
+
+        zres = requests.get(zip_url)
+        zres.raise_for_status()
+
+        target_dir = Path("csv") / "juyo" / f"{year}"
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        extracted_files: list[str] = []
+        with ZipFile(BytesIO(zres.content)) as zf:
+            for member in zf.infolist():
+                if member.is_dir():
+                    continue
+                name = Path(member.filename).name
+                dest_path = target_dir / name
+                with zf.open(member) as src, open(dest_path, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                extracted_files.append(str(dest_path))
+
+        return extracted_files
 
 
-def print_hi(name):
-    # Use a breakpoint in the code line below to debug your script.
-    print(f'Hi, {name}')  # Press Ctrl+F8 to toggle the breakpoint.
-
-
-# Press the green button in the gutter to run the script.
-if __name__ == '__main__':
-    print_hi('PyCharm')
-
-# See PyCharm help at https://www.jetbrains.com/help/pycharm/
+if __name__ == "__main__":
+    scraper = epco()
+    print(scraper.juyo(dt.date.today(), "hokkaido"))


### PR DESCRIPTION
## Summary
- add `epco` class with `juyo` method for downloading and extracting Hokkaido electricity usage CSVs

## Testing
- `python -m py_compile epco_scraper.py`
- `python - <<'PY'
from epco_scraper import epco
scraper = epco()
print(scraper.juyo('2024-05-01', 'hokkaido')[:3])
PY` *(fails: HTTPSConnectionPool host='denkiyoho.hepco.co.jp', ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_689201c724888320bc11bf726115c301