### PR TITLE
feat: organize Hokkaido data under area directory

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -60,7 +60,11 @@ class epco:
         zres = requests.get(zip_url)
         zres.raise_for_status()
 
-        target_dir = Path("csv") / "juyo" / f"{year}"
+        if area == "hokkaido":
+            area_path = "hok"
+        else:
+            area_path = area
+        target_dir = Path("csv") / "juyo" / area_path / f"{year}"
         target_dir.mkdir(parents=True, exist_ok=True)
 
         extracted_files: list[str] = []


### PR DESCRIPTION
## Summary
- organize Hokkaido juyo data into `csv/juyo/hok/YYYY`

## Testing
- `python -m py_compile epco_scraper.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68920365bf948320a80ec364079a3eb2