### PR TITLE
Use fiscal year for juyo data directory

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -27,7 +27,9 @@ class epco:
         Returns
         -------
         list[str]
-            Paths to the extracted CSV files.
+            Paths to the extracted CSV files. Files are saved under
+            ``csv/juyo/area/YYYY`` where ``YYYY`` is the fiscal year starting
+            in April.
         """
         if isinstance(date, str):
             date = dt.date.fromisoformat(date)
@@ -42,6 +44,7 @@ class epco:
         start_month = start_months[date.month]
         end_month = end_months[date.month]
         year = date.year
+        fiscal_year = year if date.month >= 4 else year - 1
 
         filename = f"{year}{start_month:02d}-{end_month:02d}_{area}_denkiyohou.zip"
 
@@ -64,7 +67,7 @@ class epco:
             area_path = "hok"
         else:
             area_path = area
-        target_dir = Path("csv") / "juyo" / area_path / f"{year}"
+        target_dir = Path("csv") / "juyo" / area_path / f"{fiscal_year}"
         target_dir.mkdir(parents=True, exist_ok=True)
 
         extracted_files: list[str] = []


### PR DESCRIPTION
## Summary
- store juyo CSV data in directories named by fiscal year starting in April
- document fiscal year convention in juyo method

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892045439808320ab361fa85b5befd3