### PR TITLE
Avoid recoding when saving Tohoku CSV

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -63,10 +63,8 @@ class epco:
             target_dir.mkdir(parents=True, exist_ok=True)
             dest_path = target_dir / csv_name
 
-            encoding = (chardet.detect(res.content).get("encoding") or "").lower()
-            text = res.content.decode(encoding)
-            with open(dest_path, "w", encoding="utf-8") as dst:
-                dst.write(text)
+            with open(dest_path, "wb") as dst:
+                dst.write(res.content)
             return [str(dest_path)]
 
         start_months = {1: 1, 2: 1, 3: 1, 4: 4, 5: 4, 6: 4, 7: 7, 8: 7, 9: 7, 10: 10, 11: 10, 12: 10}


### PR DESCRIPTION
## Summary
- write Tohoku CSV downloads without attempting to detect and recode their encoding

## Testing
- `python -m py_compile epco_scraper.py`
- `python epco_scraper.py` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892138c27788320b41214cc6d87ea04