### PR TITLE
Handle single blank lines in Tokyo CSV output

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -121,6 +121,25 @@ class epco:
 
                 encoding = (chardet.detect(data).get("encoding") or "").lower()
                 text = data.decode(encoding)
+                if area == "tokyo":
+                    # Remove only single blank lines while keeping groups of
+                    # consecutive blank lines intact. This avoids altering
+                    # blocks that use multiple blank lines as separators.
+                    lines = text.splitlines()
+                    cleaned: list[str] = []
+                    i = 0
+                    while i < len(lines):
+                        if not lines[i].strip():
+                            j = i
+                            while j < len(lines) and not lines[j].strip():
+                                j += 1
+                            if j - i > 1:
+                                cleaned.extend([""] * (j - i))
+                            i = j
+                            continue
+                        cleaned.append(lines[i])
+                        i += 1
+                    text = "\n".join(cleaned) + "\n"
                 with open(dest_path, "w", encoding="utf-8") as dst:
                     dst.write(text)
                 extracted_files.append(str(dest_path))


### PR DESCRIPTION
## Summary
- Clean up Tokyo juyo CSVs by removing standalone blank lines while keeping consecutive blank-line blocks intact

## Testing
- `python -m py_compile epco_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68921ce7260c8320961f485b4f375c22