### PR TITLE
Remove empty lines from Hokkaido CSVs

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -41,9 +41,9 @@ class epco:
         -------
         list[str]
             Paths to the extracted CSV files. For the Hokkaido area files are
-            saved under ``csv/juyo/area/YYYY`` where ``YYYY`` is the calendar
-            year. For the Tohoku area files are saved under ``csv/toh`` with
-            empty lines removed.
+            saved under ``csv/juyo/hok/YYYY`` where ``YYYY`` is the calendar
+            year with empty lines removed. For the Tohoku area files are saved
+            under ``csv/juyo/toh`` with empty lines removed.
         """
         if isinstance(date, str):
             date = dt.date.fromisoformat(date)
@@ -140,6 +140,10 @@ class epco:
                         cleaned.append(lines[i])
                         i += 1
                     text = "\n".join(cleaned) + "\n"
+                elif area == "hokkaido":
+                    # Remove all empty lines
+                    lines = [line for line in text.splitlines() if line.strip()]
+                    text = "\n".join(lines) + "\n"
                 with open(dest_path, "w", encoding="utf-8") as dst:
                     dst.write(text)
                 extracted_files.append(str(dest_path))


### PR DESCRIPTION
## Summary
- Remove empty lines from Hokkaido CSV downloads
- Document that cleaned files are stored under `csv/juyo/hok`

## Testing
- `python -m py_compile epco_scraper.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68921eba8bb483209926ab551f7c75fc