### PR TITLE
Add Chubu area scraper

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -23,6 +23,7 @@ class epco:
         "hokkaido": "https://denkiyoho.hepco.co.jp/",
         "tohoku": "https://setsuden.nw.tohoku-epco.co.jp/",
         "tokyo": "https://www.tepco.co.jp/forecast/",
+        "chubu": "https://powergrid.chuden.co.jp/denkiyoho/",
     }
 
     def juyo(self, date, area="hokkaido"):
@@ -34,8 +35,8 @@ class epco:
             Date used to determine which dataset to download. An ISO formatted
             string (``YYYY-MM-DD``) is also accepted.
         area : str, optional
-            Electricity area. Supports ``"hokkaido"``, ``"tohoku"``, and
-            ``"tokyo"``.
+            Electricity area. Supports ``"hokkaido"``, ``"tohoku"``, ``"tokyo"``,
+            and ``"chubu"``.
 
         Returns
         -------
@@ -43,7 +44,8 @@ class epco:
             Paths to the extracted CSV files. For the Hokkaido area files are
             saved under ``csv/juyo/hok/YYYY`` where ``YYYY`` is the calendar
             year with empty lines removed. For the Tohoku area files are saved
-            under ``csv/juyo/toh`` with empty lines removed.
+            under ``csv/juyo/toh`` with empty lines removed. For the Chubu area
+            files are saved under ``csv/juyo/chb/YYYY`` with empty lines removed.
         """
         if isinstance(date, str):
             date = dt.date.fromisoformat(date)
@@ -80,6 +82,9 @@ class epco:
         if area == "tokyo":
             filename = f"{year}{date.month:02d}_power_usage.zip"
             zip_url = urljoin(base_url, f"html/images/{filename}")
+        elif area == "chubu":
+            filename = f"{year}{date.month:02d}_power_usage.zip"
+            zip_url = urljoin(base_url, f"/denki_yoho_content_data/download_csv/{filename}")
         else:
             start_months = {1: 1, 2: 1, 3: 1, 4: 4, 5: 4, 6: 4, 7: 7, 8: 7, 9: 7, 10: 10, 11: 10, 12: 10}
             end_months = {1: 3, 2: 3, 3: 3, 4: 6, 5: 6, 6: 6, 7: 9, 8: 9, 9: 9, 10: 12, 11: 12, 12: 12}
@@ -104,7 +109,7 @@ class epco:
         zres = requests.get(zip_url, headers={"User-Agent": "Mozilla/5.0"})
         zres.raise_for_status()
 
-        area_map = {"hokkaido": "hok", "tokyo": "tok"}
+        area_map = {"hokkaido": "hok", "tokyo": "tok", "chubu": "chb"}
         area_path = area_map.get(area, area)
         target_dir = Path("csv") / "juyo" / area_path / f"{year}"
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -140,7 +145,7 @@ class epco:
                         cleaned.append(lines[i])
                         i += 1
                     text = "\n".join(cleaned) + "\n"
-                elif area == "hokkaido":
+                elif area in {"hokkaido", "chubu"}:
                     # Remove all empty lines
                     lines = [line for line in text.splitlines() if line.strip()]
                     text = "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- support Chubu area power usage downloads
- save Chubu data under `csv/juyo/chb/YYYY` with blank lines removed

## Testing
- `python -m py_compile epco_scraper.py`
- `python - <<'PY'
from epco_scraper import epco
from datetime import date
s = epco()
try:
    res = s.juyo(date(2024,1,1), 'chubu')
    print(res[:1])
except Exception as e:
    print('error:', type(e).__name__, e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68922100661883208ad476bcd1294240