### PR TITLE
feat: add kansai area scraping

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -21,6 +21,8 @@ class epco:
     https://www.rikuden.co.jp/nw/denki-yoho/index.html.
     The landing page for the Chugoku area is
     https://www.energia.co.jp/nw/jukyuu/index.html.
+    The landing page for the Kansai area is
+    https://www.kansai-td.co.jp/denkiyoho/download/.
     """
 
     BASE_URLS = {
@@ -29,6 +31,7 @@ class epco:
         "tokyo": "https://www.tepco.co.jp/forecast/",
         "chubu": "https://powergrid.chuden.co.jp/denkiyoho/",
         "hokuriku": "https://www.rikuden.co.jp/nw/denki-yoho/csv/",
+        "kansai": "https://www.kansai-td.co.jp/denkiyoho/download/",
     }
 
     def juyo(self, date, area="hokkaido"):
@@ -41,7 +44,7 @@ class epco:
             string (``YYYY-MM-DD``) is also accepted.
         area : str, optional
             Electricity area. Supports ``"hokkaido"``, ``"tohoku"``, ``"tokyo"``,
-            ``"chubu"``, and ``"hokuriku"``.
+            ``"chubu"``, ``"kansai"``, and ``"hokuriku"``.
 
         Returns
         -------
@@ -51,8 +54,9 @@ class epco:
             year with empty lines removed. For the Tohoku area files are saved
             under ``csv/juyo/toh`` with empty lines removed. For the Chubu area
             files are saved under ``csv/juyo/chb/YYYY`` with empty lines removed.
-            For the Hokuriku area files are saved under ``csv/hrk/YYYY`` with
-            empty lines removed.
+            For the Kansai area files are saved under ``csv/juyo/kas/YYYY`` with
+            empty lines removed. For the Hokuriku area files are saved under
+            ``csv/hrk/YYYY`` with empty lines removed.
         """
         if isinstance(date, str):
             date = dt.date.fromisoformat(date)
@@ -110,6 +114,9 @@ class epco:
         elif area == "chubu":
             filename = f"{year}{date.month:02d}_power_usage.zip"
             zip_url = urljoin(base_url, f"/denki_yoho_content_data/download_csv/{filename}")
+        elif area == "kansai":
+            filename = f"{year}{date.month:02d}_jisseki.zip"
+            zip_url = urljoin(base_url, f"yamasou/{filename}")
         else:
             start_months = {1: 1, 2: 1, 3: 1, 4: 4, 5: 4, 6: 4, 7: 7, 8: 7, 9: 7, 10: 10, 11: 10, 12: 10}
             end_months = {1: 3, 2: 3, 3: 3, 4: 6, 5: 6, 6: 6, 7: 9, 8: 9, 9: 9, 10: 12, 11: 12, 12: 12}
@@ -134,7 +141,7 @@ class epco:
         zres = requests.get(zip_url, headers={"User-Agent": "Mozilla/5.0"})
         zres.raise_for_status()
 
-        area_map = {"hokkaido": "hok", "tokyo": "tok", "chubu": "chb"}
+        area_map = {"hokkaido": "hok", "tokyo": "tok", "chubu": "chb", "kansai": "kas"}
         area_path = area_map.get(area, area)
         target_dir = Path("csv") / "juyo" / area_path / f"{year}"
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -170,7 +177,7 @@ class epco:
                         cleaned.append(lines[i])
                         i += 1
                     text = "\n".join(cleaned) + "\n"
-                elif area in {"hokkaido", "chubu"}:
+                elif area in {"hokkaido", "chubu", "kansai"}:
                     # Remove all empty lines
                     lines = [line for line in text.splitlines() if line.strip()]
                     text = "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add Kansai base URL and option to the EPCO scraper
- handle Kansai monthly archives and save to `csv/juyo/kas/<year>`
- normalise CSV encoding and remove empty lines

## Testing
- `python -m py_compile epco_scraper.py`
- `python - <<'PY'
from epco_scraper import epco
scraper=epco()
files=scraper.juyo('2024-08-01','kansai')
print(len(files), 'files downloaded')
print(files[:5])
PY` *(fails: HTTPSConnectionPool(host='www.kansai-td.co.jp', port=443): Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68922a6a14a883209a01ab832cf08069