### PR TITLE
Add Shikoku area support

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -23,6 +23,8 @@ class epco:
     https://www.energia.co.jp/nw/jukyuu/index.html.
     The landing page for the Kansai area is
     https://www.kansai-td.co.jp/denkiyoho/download/.
+    The landing page for the Shikoku area is
+    https://www.yonden.co.jp/nw/denkiyoho/download.html.
     """
 
     BASE_URLS = {
@@ -32,6 +34,7 @@ class epco:
         "chubu": "https://powergrid.chuden.co.jp/denkiyoho/",
         "hokuriku": "https://www.rikuden.co.jp/nw/denki-yoho/csv/",
         "kansai": "https://www.kansai-td.co.jp/",
+        "shikoku": "https://www.yonden.co.jp/nw/denkiyoho/csv/",
     }
 
     def juyo(self, date, area="hokkaido"):
@@ -44,7 +47,7 @@ class epco:
             string (``YYYY-MM-DD``) is also accepted.
         area : str, optional
             Electricity area. Supports ``"hokkaido"``, ``"tohoku"``, ``"tokyo"``,
-            ``"chubu"``, ``"kansai"``, and ``"hokuriku"``.
+            ``"chubu"``, ``"kansai"``, ``"hokuriku"``, and ``"shikoku"``.
 
         Returns
         -------
@@ -56,7 +59,8 @@ class epco:
             files are saved under ``csv/juyo/chb/YYYY`` with empty lines removed.
             For the Kansai area files are saved under ``csv/juyo/kas/YYYY`` with
             empty lines removed. For the Hokuriku area files are saved under
-            ``csv/hrk/YYYY`` with empty lines removed.
+            ``csv/hrk/YYYY`` with empty lines removed. For the Shikoku area
+            files are saved under ``csv/juyo/shi`` with empty lines removed.
         """
         if isinstance(date, str):
             date = dt.date.fromisoformat(date)
@@ -84,6 +88,24 @@ class epco:
             encoding = chardet.detect(res.content).get("encoding") or "shift_jis"
             text = res.content.decode(encoding)
             # Remove empty lines from the CSV text
+            lines = [line for line in text.splitlines() if line.strip()]
+            cleaned = "\n".join(lines) + "\n"
+            with open(dest_path, "w", encoding="utf-8") as dst:
+                dst.write(cleaned)
+            return [str(dest_path)]
+
+        if area == "shikoku":
+            csv_name = f"juyo_shikoku_{year}.csv"
+            csv_url = urljoin(base_url, csv_name)
+            res = requests.get(csv_url, headers={"User-Agent": "Mozilla/5.0"})
+            res.raise_for_status()
+
+            target_dir = Path("csv") / "juyo" / "shi"
+            target_dir.mkdir(parents=True, exist_ok=True)
+            dest_path = target_dir / csv_name
+
+            encoding = chardet.detect(res.content).get("encoding") or "shift_jis"
+            text = res.content.decode(encoding)
             lines = [line for line in text.splitlines() if line.strip()]
             cleaned = "\n".join(lines) + "\n"
             with open(dest_path, "w", encoding="utf-8") as dst:


### PR DESCRIPTION
## Summary
- support Shikoku electricity usage CSV downloads
- document Shikoku landing page

## Testing
- `python -m py_compile epco_scraper.py`
- `python - <<'PY'
import datetime as dt
from epco_scraper import epco
scraper = epco()
res = scraper.juyo(dt.date(2025,1,1), 'shikoku')
print(res)
PY` *(fails: HTTPSConnectionPool(host='www.yonden.co.jp', port=443): Max retries exceeded with url: /nw/denkiyoho/csv/juyo_shikoku_2025.csv (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*


------
https://chatgpt.com/codex/tasks/task_e_68922d0a70d88320a2931ee9c5b97d11