### PR TITLE
Add Okinawa area daily data support

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -27,6 +27,8 @@ class epco:
     https://www.yonden.co.jp/nw/denkiyoho/download.html.
     The landing page for the Kyushu area is
     https://www.kyuden.co.jp/td_power_usages/.
+    The landing page for the Okinawa area is
+    https://www.okiden.co.jp/denki2/.
     """
 
     BASE_URLS = {
@@ -38,6 +40,7 @@ class epco:
         "kansai": "https://www.kansai-td.co.jp/",
         "shikoku": "https://www.yonden.co.jp/nw/denkiyoho/csv/",
         "kyushu": "https://www.kyuden.co.jp/td_power_usages/csv/",
+        "okinawa": "https://www.okiden.co.jp/denki2/",
     }
 
     def juyo(self, date, area="hokkaido"):
@@ -50,8 +53,8 @@ class epco:
             string (``YYYY-MM-DD``) is also accepted.
         area : str, optional
             Electricity area. Supports ``"hokkaido"``, ``"tohoku"``, ``"tokyo"``,
-            ``"chubu"``, ``"kansai"``, ``"hokuriku"``, ``"shikoku"``, and
-            ``"kyushu"``.
+            ``"chubu"``, ``"kansai"``, ``"hokuriku"``, ``"shikoku"``, ``"kyushu"``,
+            and ``"okinawa"``.
 
         Returns
         -------
@@ -66,7 +69,8 @@ class epco:
             ``csv/hrk/YYYY`` with empty lines removed. For the Shikoku area
             files are saved under ``csv/juyo/shi`` with empty lines removed. For
             the Kyushu area files are saved under ``csv/juyo/kyu/YYYY`` with
-            empty lines removed.
+            empty lines removed. For the Okinawa area files are saved under
+            ``csv/juyo/oki/YYYY`` with empty lines removed.
         """
         if isinstance(date, str):
             date = dt.date.fromisoformat(date)
@@ -125,6 +129,24 @@ class epco:
             res.raise_for_status()
 
             target_dir = Path("csv") / "juyo" / "kyu" / f"{year}"
+            target_dir.mkdir(parents=True, exist_ok=True)
+            dest_path = target_dir / csv_name
+
+            encoding = chardet.detect(res.content).get("encoding") or "shift_jis"
+            text = res.content.decode(encoding)
+            lines = [line for line in text.splitlines() if line.strip()]
+            cleaned = "\n".join(lines) + "\n"
+            with open(dest_path, "w", encoding="utf-8") as dst:
+                dst.write(cleaned)
+            return [str(dest_path)]
+
+        if area == "okinawa":
+            csv_name = f"juyo_10_{date:%Y%m%d}.csv"
+            csv_url = urljoin(base_url, csv_name)
+            res = requests.get(csv_url, headers={"User-Agent": "Mozilla/5.0"})
+            res.raise_for_status()
+
+            target_dir = Path("csv") / "juyo" / "oki" / f"{year}"
             target_dir.mkdir(parents=True, exist_ok=True)
             dest_path = target_dir / csv_name
 


### PR DESCRIPTION
## Summary
- add Okinawa landing/base URLs and documentation to epco scraper
- handle Okinawa daily CSV downloads and save under `csv/juyo/oki/YYYY`

## Testing
- `python -m py_compile epco_scraper.py`
- `python - <<'PY'
import datetime as dt
from epco_scraper import epco
s = epco()
try:
    print('trying...')
    res = s.juyo(dt.date(2024,8,1), 'okinawa')
    print('result', res)
except Exception as e:
    print('error', type(e).__name__, e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6892340e50a483208e9e35dd9a2d6ef6