### PR TITLE
Support pre-2022 Tokyo CSV data

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -197,6 +197,24 @@ class epco:
             return [str(dest_path)]
 
         if area == "tokyo":
+            if date < dt.date(2022, 4, 1):
+                csv_name = f"juyo-{year}.csv"
+                csv_url = urljoin(base_url, f"html/images/{csv_name}")
+                res = requests.get(csv_url, headers={"User-Agent": "Mozilla/5.0"})
+                res.raise_for_status()
+
+                target_dir = Path("csv") / "juyo" / "tok" / f"{year}"
+                target_dir.mkdir(parents=True, exist_ok=True)
+                dest_path = target_dir / csv_name
+
+                encoding = chardet.detect(res.content).get("encoding") or "shift_jis"
+                text = res.content.decode(encoding)
+                lines = [line for line in text.splitlines() if line.strip()]
+                cleaned = "\n".join(lines) + "\n"
+                with open(dest_path, "w", encoding="utf-8") as dst:
+                    dst.write(cleaned)
+                return [str(dest_path)]
+
             filename = f"{year}{date.month:02d}_power_usage.zip"
             zip_url = urljoin(base_url, f"html/images/{filename}")
         elif area == "chubu":


### PR DESCRIPTION
## Summary
- handle Tokyo power usage data before April 2022 using yearly CSV endpoint
- decode legacy CSVs and strip empty lines before saving to `csv/juyo/tok/<year>`

## Testing
- `python -m py_compile epco_scraper.py`
- `python - <<'PY'
from epco_scraper import epco
from datetime import date
scraper = epco()
try:
    print('Fetching 2021 tokyo...')
    paths = scraper.juyo(date(2021, 1, 1), 'tokyo')
    print('Result', paths)
except Exception as e:
    print('Error', e)
PY` *(fails: ProxyError 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68923d62a95483209006952da4878696