### PR TITLE
Add earliest year summary table for EPCO regions

### DIFF
--- a/epco_scraper.py
+++ b/epco_scraper.py
@@ -8,6 +8,23 @@ from zipfile import ZipFile
 import chardet
 
 
+# Earliest available year for each region based on existing CSV files.
+# | Region   | Earliest Year |
+# |----------|---------------|
+# | hokkaido | 2020          |
+# | tohoku   | 2015          |
+# | tokyo    | 2008          |
+# | chubu    | 2019          |
+# | chugoku  | 2019          |
+# | hokuriku | 2019          |
+# | kansai   | 2016          |
+# | shikoku  | 2016          |
+# | kyushu   | 2012          |
+# | okinawa  | 2016          |
+#
+# TODO: Fill in data for earlier years where available.
+
+
 class epco:
     """Scraper for EPCO electricity usage data.
 


### PR DESCRIPTION
## Summary
- document earliest available data year for each region as a table comment in `epco_scraper.py`

## Testing
- `python -m py_compile epco_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_689240b9d72083209678a828b8e6d877