### PR TITLE
Add script to fetch previous day's EPCO usage

### DIFF
--- a/run_epco_juyo.py
+++ b/run_epco_juyo.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timedelta
+import sys
+
+from epco_scraper import epco
+
+
+if __name__ == "__main__":
+    yesterday = datetime.today() - timedelta(days=1)
+
+    scraper = epco()
+    try:
+        paths = scraper.juyo(date=yesterday.strftime("%Y%m%d"))
+        for path in paths:
+            print(path)
+    except RuntimeError as err:
+        print(err)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add `run_epco_juyo.py` script to download EPCO demand data for the previous day

## Testing
- `pip install requests chardet`
- `python run_epco_juyo.py` *(fails: ProxyError: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6892422c0a9c832095b3eacefabd2b01