### PR TITLE
feat: iterate over all EPCO areas

### DIFF
--- a/run_epco_juyo.py
+++ b/run_epco_juyo.py
@@ -4,14 +4,29 @@ import sys
 from epco_scraper import epco
 
 
+AREAS = [
+    "hokkaido",
+    "tohoku",
+    "tokyo",
+    "chubu",
+    "chugoku",
+    "hokuriku",
+    "kansai",
+    "shikoku",
+    "kyushu",
+    "okinawa",
+]
+
+
 if __name__ == "__main__":
     yesterday = datetime.today() - timedelta(days=1)
 
     scraper = epco()
-    try:
-        paths = scraper.juyo(date=yesterday.strftime("%Y%m%d"))
-        for path in paths:
-            print(path)
-    except RuntimeError as err:
-        print(err)
-        sys.exit(1)
+    for area in AREAS:
+        try:
+            paths = scraper.juyo(date=yesterday.strftime("%Y%m%d"), area=area)
+            for path in paths:
+                print(path)
+        except RuntimeError as err:
+            print(err)
+            sys.exit(1)


### PR DESCRIPTION
## Summary
- loop juyo scraping over all EPCO areas

## Testing
- `python run_epco_juyo.py` *(fails: HTTPSConnectionPool(host='denkiyoho.hepco.co.jp', port=443): Max retries exceeded with url)*

------
https://chatgpt.com/codex/tasks/task_e_6892433c29d08320b6b0766e8bfbce81